### PR TITLE
add a property that indicates an object is a MLIR sparse tensor

### DIFF
--- a/metagraph_mlir/types.py
+++ b/metagraph_mlir/types.py
@@ -47,6 +47,10 @@ if has_mlir_graphblas:
             self.node_list: np.ndarray = node_list
             self.node_vals: np.ndarray = node_vals
 
+        @property
+        def __mlir_sparse__(self):
+            return self.value
+
         class TypeMixin:
             @classmethod
             def _compute_abstract_properties(


### PR DESCRIPTION
Use in conjunction with metagraph-dev/mlir-graphblas#37